### PR TITLE
Fixed deprecated methods.

### DIFF
--- a/CocoaLibSpotify.podspec
+++ b/CocoaLibSpotify.podspec
@@ -1,0 +1,67 @@
+Pod::Spec.new do |s|
+  s.name         =  'CocoaLibSpotify'
+  s.version      =  '2.4.6'
+  s.author       =  'Spotify'
+  s.license      =  'BSD 3-Clause'
+  s.homepage     =  'https://github.com/spotify/cocoalibspotify'
+  s.summary      =  'A Cocoa wrapper for libspotify.'
+  s.description  =  "CocoaLibSpotify is an Objective-C wrapper around our libspotify library. It provides easy access to libspotify's features in a friendly, KVC/O compliant Objective-C wrapper."
+  s.source       =  { :git => 'https://github.com/spotify/cocoalibspotify.git', :tag => "2.4.6" }
+  s.requires_arc =  true
+  s.preserve_paths = 'libspotify-12.1.64-iOS-universal'
+  s.source_files =  'common', 'iOS Library/View Controllers', 'libspotify-12.1.64-iOS-universal/libspotify.framework/Versions/12.1.64/Headers'
+  s.resource     =  'iOS Library/SPLoginResources.bundle'
+  s.frameworks   =  'SystemConfiguration', 'CFNetwork', 'CoreAudio', 'AudioToolbox', 'AVFoundation', 'libspotify'
+  s.library      =  'stdc++'
+  s.xcconfig     =  { 'OTHER_LDFLAGS' => '-all_load', 'FRAMEWORK_SEARCH_PATHS' => '$(PODS_ROOT)/CocoaLibSpotify/libspotify-12.1.64-iOS-universal' }
+  s.platform     =  :ios
+
+  def s.pre_install(pod, target)
+    # Note: Taken straight from the libspotify build script step
+    system <<-CMD
+python -c "
+import socket
+socket.setdefaulttimeout(60)
+import urllib
+import zipfile
+import os
+import sys
+import commands
+
+libspotifyFileName = \\"libspotify-12.1.64-iOS-universal.zip\\"
+libspotifyRemoteLocation = \\"http://developer.spotify.com/download/libspotify/\\"
+projectDir = \\"#{pod.root}\\"
+libspotifyDirectoryDir = os.path.join(projectDir, \\"libspotify-12.1.64-iOS-universal\\")
+libspotifyZipDir = os.path.join(projectDir, libspotifyFileName)
+
+if (os.path.exists(libspotifyDirectoryDir)):
+    #print \\"LibSpotify is present, no download needed.\\"
+    sys.exit(0)
+
+print \\"LibSpotify not present, downloading...\\"
+
+try:
+    urllib.urlretrieve(libspotifyRemoteLocation + libspotifyFileName, libspotifyZipDir)
+except OSError:
+    print \\"Could not download \\" + libspotifyRemoteLocation + libspotifyFileName + \\".\\"
+    sys.exit(1)
+
+unzipCommand = 'unzip -q \\"' + libspotifyZipDir + '\\"' + ' -d \\"' + projectDir + '\\"'
+unzipResult = commands.getstatusoutput(unzipCommand)
+
+if (unzipResult[0] != 0):
+    print \\"Could not untar \\" + libspotifyFileName + \\".\\"
+    sys.exit(1)
+
+commands.getstatusoutput('rm -rf \\"' + projectDir + '/__MACOSX\\"') 
+
+try:
+    os.remove(libspotifyZipDir)
+except OSError:
+    print \\"Could not remove downloaded file.\\"
+
+print \\"Complete.\\"
+"
+CMD
+  end
+end

--- a/common/SPSession.m
+++ b/common/SPSession.m
@@ -1584,7 +1584,7 @@ static SPSession *sharedSession;
 
 -(void)resetProdTimerWithTimeout:(NSTimeInterval)timeout {
 
-	NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"Not on main thread!");
+	NSAssert([NSThread isMainThread], @"Not on main thread!");
 
 	[self.prodTimeoutTimer invalidate];
 	self.prodTimeoutTimer = nil;

--- a/iOS Library/CocoaLibSpotify iOS Library.xcodeproj/project.pbxproj
+++ b/iOS Library/CocoaLibSpotify iOS Library.xcodeproj/project.pbxproj
@@ -792,7 +792,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CocoaLibSpotify iOS Library-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/libspotify-12.1.64-iOS-universal/libspotify.framework/Versions/12.1.64\"",
@@ -813,7 +813,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CocoaLibSpotify iOS Library-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/libspotify-12.1.64-iOS-universal/libspotify.framework/Versions/12.1.64\"",

--- a/iOS Library/View Controllers/SPLicenseViewController.m
+++ b/iOS Library/View Controllers/SPLicenseViewController.m
@@ -64,9 +64,9 @@ static NSString * const kSPLicensesFormatter = @"http://www.spotify.com/mobile/e
 	UIViewController *parent = self.navigationController;
 	
 	if ([parent respondsToSelector:@selector(presentingViewController)]) {
-		[parent.presentingViewController dismissModalViewControllerAnimated:YES];
+		[parent.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 	} else {
-		[parent.parentViewController dismissModalViewControllerAnimated:YES];
+		[parent.parentViewController dismissViewControllerAnimated:YES completion:nil];
 	}
 }
 

--- a/iOS Library/View Controllers/SPLoginLogicViewController.m
+++ b/iOS Library/View Controllers/SPLoginLogicViewController.m
@@ -261,7 +261,7 @@
 	loggingInLabel.font = [UIFont systemFontOfSize:14.0];
 	loggingInLabel.textColor = [UIColor colorWithWhite:0.3 alpha:1.0];
 	loggingInLabel.backgroundColor = [UIColor whiteColor];
-	loggingInLabel.textAlignment = UITextAlignmentCenter;
+	loggingInLabel.textAlignment = NSTextAlignmentCenter;
 	
 	[self.loggingInView addSubview:loggingInLabel];
 	[self.loginFormView addSubview:self.loggingInView];

--- a/iOS Library/View Controllers/SPLoginLogicViewController.m
+++ b/iOS Library/View Controllers/SPLoginLogicViewController.m
@@ -316,7 +316,7 @@
     [super viewWillAppear:animated];
 
 	previousStyle = [[UIApplication sharedApplication] statusBarStyle];
-	[[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleBlackOpaque animated:animated];
+	[[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault animated:animated];
 }
 
 -(void)viewWillDisappear:(BOOL)animated {

--- a/iOS Library/View Controllers/SPLoginViewController.m
+++ b/iOS Library/View Controllers/SPLoginViewController.m
@@ -165,7 +165,7 @@ static NSMutableDictionary *loginControllerCache;
 				nav.navigationBar.barStyle = UIBarStyleBlack;
 				nav.modalPresentationStyle = UIModalPresentationFormSheet;
 				
-				[self presentModalViewController:nav animated:YES];
+				[self presentViewController:nav animated:YES completion:nil];
 			});
 		});
 		
@@ -269,7 +269,7 @@ static NSMutableDictionary *loginControllerCache;
 	if (parent == nil)
 		return;
 	
-	[parent presentModalViewController:self animated:NO];
+	[parent presentViewController:self animated:NO completion:nil];
 }
 
 @end
@@ -296,17 +296,17 @@ static NSMutableDictionary *loginControllerCache;
 		
 		vc.completionBlock = ^() {
 			if (self.dismissesAfterLogin) {
-				[targetViewController dismissModalViewControllerAnimated:YES];
+				[targetViewController dismissViewControllerAnimated:YES completion:nil];
 			}
 			[self.loginDelegate loginViewController:self didCompleteSuccessfully:success];
 		};
 		
-		[targetViewController dismissModalViewControllerAnimated:NO];
-		[targetViewController presentModalViewController:nav animated:NO];
+		[targetViewController dismissViewControllerAnimated:NO completion:nil];
+		[targetViewController presentViewController:nav animated:NO completion:nil];
 		return;
 	}
 	
-	[targetViewController dismissModalViewControllerAnimated:YES];
+	[targetViewController dismissViewControllerAnimated:YES completion:nil];
 	[self.loginDelegate loginViewController:self didCompleteSuccessfully:success];
 }
 
@@ -314,7 +314,7 @@ static NSMutableDictionary *loginControllerCache;
 	
 	if (page == SP_SIGNUP_PAGE_DONE) {
 		if (self.isShown && !self.waitingForFacebookPermissions) {
-			[self dismissModalViewControllerAnimated:YES];
+			[self dismissViewControllerAnimated:YES completion:nil];
 		}
 		self.didReceiveSignupFlow = NO;
 		return;

--- a/iOS Library/View Controllers/SPSignupViewController.m
+++ b/iOS Library/View Controllers/SPSignupViewController.m
@@ -283,7 +283,7 @@
 	nav.navigationBar.barStyle = UIBarStyleBlack;
 	nav.modalPresentationStyle = UIModalPresentationFormSheet;
  
-	[self presentModalViewController:nav animated:YES];
+	[self presentViewController:nav animated:YES completion:nil];
 }
 
 #pragma mark Merge page


### PR DESCRIPTION
Note that this bumps minimum target to 6.0, and also requires the creation of a 2.4.6 tag.
